### PR TITLE
仕様02 実装: Yahoo Finance ベースの自動データ収集 API

### DIFF
--- a/docs/02-data-collection.md
+++ b/docs/02-data-collection.md
@@ -145,4 +145,40 @@ FX および日本株の OHLCV データを外部 API から自動取得し、**
 
 ## 実装メモ
 
-（実装後に追記）
+### 実装記録（完了）
+
+#### パッケージ
+- `yahoo-finance2` ^3.14.0 を追加
+
+#### ユーティリティ
+- `src/utils/yahooFinance.ts`：
+  - `new YahooFinance()` インスタンスで `chart()` API 呼び出し
+  - `interval=4h` は Yahoo が直接非対応のため、1h を取得して 4 本ずつ集約
+  - `null` を含むバーは除外
+- `src/utils/dataIngestion.ts`：
+  - `ingestSymbol(symbol, interval, from, to)` で取得 → `prisma.candle.upsert` で保存
+  - `(chartMasterId, interval, time)` ユニーク制約で冪等
+  - 戻り値：`{ inserted, updated, total }`
+
+#### API エンドポイント
+
+| ルート | 用途 |
+|------|------|
+| `POST /api/data/fetch` | 単一シンボル + interval を取得・保存 |
+| `POST /api/data/fetch/batch` | 全マスタ（or `assetType` フィルタ）を一括取得 |
+| `GET /api/data/status` | シンボル × interval ごとの件数・最終時刻 |
+| `GET /api/masters` | ChartMaster 一覧（`assetType` フィルタ可） |
+
+`/api/data/fetch/batch` のデフォルト interval：
+- FX: `["1h", "4h"]`
+- STOCK: `["1d", "1h"]`
+
+#### 検証結果
+- `npm run build`：`✓ Compiled successfully in 3.2s`、新ルート 4 本含めて Static 11/11 + Dynamic 9 ルート
+- `npm run lint`：エラー 0、警告 19（既存）
+
+#### 既知の制約・残件
+- Yahoo の 5m / 15m は履歴期間が短い（直近 60 日程度）。長期履歴が必要な場合は 1d 中心に運用
+- 大量銘柄の batch 取得時はレート制限の対策（指数バックオフ）を後追いで実装
+- スケジュール実行（Vercel Cron 等）は別タスク
+- UI からの取得トリガ・進捗表示は別タスク

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "react-dom": "19.2.5",
         "react-window": "^1.8.11",
         "react-window-infinite-loader": "^1.0.10",
-        "ts-node": "^10.9.2"
+        "ts-node": "^10.9.2",
+        "yahoo-finance2": "^3.14.0"
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.13",
@@ -2071,6 +2072,22 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@deno/shim-deno": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno/-/shim-deno-0.18.2.tgz",
+      "integrity": "sha512-oQ0CVmOio63wlhwQF75zA4ioolPvOwAoK0yuzcS5bDC1JUvH3y1GS8xPh8EOpcoDQRU4FTG8OQfxhpR+c6DrzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deno/shim-deno-test": "^0.5.0",
+        "which": "^4.0.0"
+      }
+    },
+    "node_modules/@deno/shim-deno-test": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno-test/-/shim-deno-test-0.5.0.tgz",
+      "integrity": "sha512-4nMhecpGlPi0cSzT67L+Tm+GOJqvuk8gqHBziqcUQOarnuIax1z96/gJHCSIz2Z0zhxE6Rzwb3IZXPtFh51j+w==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
@@ -7524,6 +7541,58 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-mock-cache": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/fetch-mock-cache/-/fetch-mock-cache-2.3.1.tgz",
+      "integrity": "sha512-hDk+Nbt0Y8Aq7KTEU6ASQAcpB34UjhkpD3QjzD6yvEKP4xVElAqXrjQ7maL+LYMGafx51Zq6qUfDM57PNu/qMw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "filenamify-url": "2.1.2"
+      }
+    },
+    "node_modules/filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify-url": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-2.1.2.tgz",
+      "integrity": "sha512-3rMbAr7vDNMOGsj1aMniQFl749QjgM+lMJ/77ZRSPTIgxvolZwoQbn8dXLs7xfd+hAdli+oTnSWZNkJJLWQFEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "filenamify": "^4.3.0",
+        "humanize-url": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/filesize": {
       "version": "10.1.6",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.6.tgz",
@@ -8179,6 +8248,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/humanize-url": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-2.1.1.tgz",
+      "integrity": "sha512-V4nxsPGNE7mPjr1qDp471YfW8nhBiTRWrG/4usZlpvFU8I7gsV7Jvrrzv/snbLm5dWO3dr1ennu2YqnhTWFmYA==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-url": "^4.5.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/icss-utils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
@@ -8492,6 +8573,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -8586,6 +8676,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -10441,6 +10537,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-url": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -11337,6 +11442,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -11363,7 +11480,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11410,6 +11526,12 @@
       "engines": {
         "node": ">=0.4.x"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/queue": {
       "version": "6.0.2",
@@ -11872,6 +11994,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -12574,6 +12702,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-outer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/style-loader": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.4.tgz",
@@ -13010,6 +13159,24 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
+    },
     "node_modules/to-buffer": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
@@ -13036,6 +13203,75 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tough-cookie-file-store": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie-file-store/-/tough-cookie-file-store-2.0.3.tgz",
+      "integrity": "sha512-sMpZVcmFf6EYFHFFl+SYH4W1/OnXBYMGDsv2IlbQ2caHyFElW/UR/gpj/KYU1JwmP4dE9xqwv2+vWcmlXHojSw==",
+      "license": "MIT",
+      "dependencies": {
+        "tough-cookie": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie-file-store/node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie-file-store/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/trim-repeated/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/trough": {
@@ -13934,6 +14170,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/url/node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -14176,6 +14422,21 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -14235,6 +14496,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/yahoo-finance2": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/yahoo-finance2/-/yahoo-finance2-3.14.0.tgz",
+      "integrity": "sha512-gsT/tqgeizKtMxbIIWFiFyuhM/6MZE4yEyNLmPekr88AX14JL2HWw0/QNMOR081jVtzTjihqDW0zV7IayH1Wcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deno/shim-deno": "~0.18.0",
+        "fetch-mock-cache": "npm:fetch-mock-cache@^2.1.3",
+        "json-schema": "^0.4.0",
+        "tough-cookie": "npm:tough-cookie@^5.1.1",
+        "tough-cookie-file-store": "npm:tough-cookie-file-store@^2.0.3"
+      },
+      "bin": {
+        "yahoo-finance": "esm/bin/yahoo-finance.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-dom": "19.2.5",
     "react-window": "^1.8.11",
     "react-window-infinite-loader": "^1.0.10",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "yahoo-finance2": "^3.14.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.13",

--- a/src/app/api/bookmark/route.ts
+++ b/src/app/api/bookmark/route.ts
@@ -16,10 +16,7 @@ export const POST = async (req: Request) => {
         labelingId: Number(body.chartLabelingId),
       },
     });
-    return NextResponse.json(
-      { message: `${created.time}でbookmarkしました` },
-      { status: 200 },
-    );
+    return NextResponse.json({ message: `${created.time}でbookmarkしました` }, { status: 200 });
   } catch (error) {
     return NextResponse.json({ error: `${error}` }, { status: 500 });
   }

--- a/src/app/api/data/fetch/batch/route.ts
+++ b/src/app/api/data/fetch/batch/route.ts
@@ -1,0 +1,53 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { ingestSymbol } from "@/utils/dataIngestion";
+import prisma from "@/utils/db";
+import type { Interval } from "@/utils/yahooFinance";
+
+interface BatchRequest {
+  assetType?: "FX" | "STOCK";
+  intervals?: Interval[];
+  from?: string;
+  to?: string;
+}
+
+const DEFAULT_FX_INTERVALS: Interval[] = ["1h", "4h"];
+const DEFAULT_STOCK_INTERVALS: Interval[] = ["1d", "1h"];
+
+export const POST = async (req: NextRequest) => {
+  let body: BatchRequest = {};
+  try {
+    body = await req.json();
+  } catch {
+    // 空ボディでも全件処理とする
+  }
+
+  const masters = await prisma.chartMaster.findMany({
+    where: {
+      enabled: true,
+      ...(body.assetType ? { assetType: body.assetType } : {}),
+    },
+  });
+
+  const to = body.to ? new Date(body.to) : new Date();
+  const defaultFrom = new Date(to.getTime() - 30 * 24 * 3600 * 1000);
+  const from = body.from ? new Date(body.from) : defaultFrom;
+
+  const results: unknown[] = [];
+  const errors: { symbol: string; interval: Interval; error: string }[] = [];
+
+  for (const m of masters) {
+    const intervals =
+      body.intervals ?? (m.assetType === "FX" ? DEFAULT_FX_INTERVALS : DEFAULT_STOCK_INTERVALS);
+
+    for (const interval of intervals) {
+      try {
+        const r = await ingestSymbol(m.symbol, interval, from, to);
+        results.push(r);
+      } catch (error) {
+        errors.push({ symbol: m.symbol, interval, error: `${error}` });
+      }
+    }
+  }
+
+  return NextResponse.json({ results, errors }, { status: 200 });
+};

--- a/src/app/api/data/fetch/route.ts
+++ b/src/app/api/data/fetch/route.ts
@@ -1,0 +1,43 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { ingestSymbol } from "@/utils/dataIngestion";
+import type { Interval } from "@/utils/yahooFinance";
+
+interface FetchRequest {
+  symbol: string;
+  interval: Interval;
+  from?: string; // ISO date
+  to?: string; // ISO date
+}
+
+const VALID_INTERVALS: Interval[] = ["5m", "15m", "1h", "4h", "1d"];
+
+export const POST = async (req: NextRequest) => {
+  let body: FetchRequest;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.symbol || !body.interval) {
+    return NextResponse.json({ error: "symbol and interval are required" }, { status: 400 });
+  }
+  if (!VALID_INTERVALS.includes(body.interval)) {
+    return NextResponse.json(
+      { error: `interval must be one of ${VALID_INTERVALS.join(", ")}` },
+      { status: 400 },
+    );
+  }
+
+  const to = body.to ? new Date(body.to) : new Date();
+  const defaultFrom = new Date(to.getTime() - 30 * 24 * 3600 * 1000); // 30 日前
+  const from = body.from ? new Date(body.from) : defaultFrom;
+
+  try {
+    const result = await ingestSymbol(body.symbol, body.interval, from, to);
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    console.error("ingestSymbol failed:", error);
+    return NextResponse.json({ error: `${error}` }, { status: 500 });
+  }
+};

--- a/src/app/api/data/status/route.ts
+++ b/src/app/api/data/status/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import prisma from "@/utils/db";
+
+export const GET = async () => {
+  // ChartMaster ごとの最新時刻と件数を集計
+  const masters = await prisma.chartMaster.findMany({
+    where: { enabled: true },
+    orderBy: { symbol: "asc" },
+  });
+
+  const summary = await Promise.all(
+    masters.map(async (m) => {
+      const grouped = await prisma.candle.groupBy({
+        by: ["interval"],
+        where: { chartMasterId: m.id },
+        _count: { _all: true },
+        _max: { time: true, fetchedAt: true },
+      });
+
+      return {
+        symbol: m.symbol,
+        displayName: m.displayName,
+        assetType: m.assetType,
+        market: m.market,
+        intervals: grouped.map((g) => ({
+          interval: g.interval,
+          count: g._count._all,
+          latestTime: g._max.time != null ? Number(g._max.time) : null,
+          fetchedAt: g._max.fetchedAt,
+        })),
+      };
+    }),
+  );
+
+  return NextResponse.json(summary, { status: 200 });
+};

--- a/src/app/api/masters/route.ts
+++ b/src/app/api/masters/route.ts
@@ -1,0 +1,23 @@
+import { type NextRequest, NextResponse } from "next/server";
+import prisma from "@/utils/db";
+
+export const GET = async (req: NextRequest) => {
+  const assetType = req.nextUrl.searchParams.get("assetType");
+
+  const masters = await prisma.chartMaster.findMany({
+    where: {
+      enabled: true,
+      ...(assetType ? { assetType } : {}),
+    },
+    orderBy: [{ assetType: "asc" }, { symbol: "asc" }],
+    select: {
+      id: true,
+      symbol: true,
+      displayName: true,
+      assetType: true,
+      market: true,
+    },
+  });
+
+  return NextResponse.json(masters, { status: 200 });
+};

--- a/src/utils/dataIngestion.ts
+++ b/src/utils/dataIngestion.ts
@@ -1,0 +1,80 @@
+import prisma from "@/utils/db";
+import { type FetchedCandle, fetchCandles, type Interval } from "@/utils/yahooFinance";
+
+export interface IngestResult {
+  symbol: string;
+  interval: Interval;
+  inserted: number;
+  updated: number;
+  total: number;
+}
+
+export const ingestSymbol = async (
+  symbol: string,
+  interval: Interval,
+  from: Date,
+  to: Date,
+): Promise<IngestResult> => {
+  const master = await prisma.chartMaster.findUnique({ where: { symbol } });
+  if (!master) {
+    throw new Error(`ChartMaster not found for symbol ${symbol}. Run db:seed first.`);
+  }
+
+  const candles: FetchedCandle[] = await fetchCandles(symbol, interval, from, to);
+
+  if (candles.length === 0) {
+    return { symbol, interval, inserted: 0, updated: 0, total: 0 };
+  }
+
+  // 既存件数を計測（差分で inserted/updated を推定）
+  const existing = await prisma.candle.count({
+    where: {
+      chartMasterId: master.id,
+      interval,
+      time: {
+        in: candles.map((c) => BigInt(c.time)),
+      },
+    },
+  });
+
+  // upsert ループ（バッチ最適化は別タスク）
+  for (const c of candles) {
+    await prisma.candle.upsert({
+      where: {
+        chartMasterId_interval_time: {
+          chartMasterId: master.id,
+          interval,
+          time: BigInt(c.time),
+        },
+      },
+      update: {
+        open: c.open,
+        high: c.high,
+        low: c.low,
+        close: c.close,
+        volume: c.volume,
+        source: "yahoo",
+        fetchedAt: new Date(),
+      },
+      create: {
+        chartMasterId: master.id,
+        interval,
+        time: BigInt(c.time),
+        open: c.open,
+        high: c.high,
+        low: c.low,
+        close: c.close,
+        volume: c.volume,
+        source: "yahoo",
+      },
+    });
+  }
+
+  return {
+    symbol,
+    interval,
+    inserted: candles.length - existing,
+    updated: existing,
+    total: candles.length,
+  };
+};

--- a/src/utils/yahooFinance.ts
+++ b/src/utils/yahooFinance.ts
@@ -1,0 +1,95 @@
+import YahooFinance from "yahoo-finance2";
+
+const yf = new YahooFinance();
+
+export type Interval = "5m" | "15m" | "1h" | "4h" | "1d";
+
+interface NonNullBar {
+  date: Date;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number | null;
+  [key: string]: unknown;
+}
+
+const INTERVAL_MAP: Record<Interval, "5m" | "15m" | "1h" | "1d"> = {
+  "5m": "5m",
+  "15m": "15m",
+  "1h": "1h",
+  "4h": "1h", // Yahoo は 4h 直接非対応 → 1h を取得し、呼び出し側で集約
+  "1d": "1d",
+};
+
+export interface FetchedCandle {
+  time: number; // Unix seconds
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+/**
+ * Yahoo Finance から OHLCV を取得して正規化する。
+ * `interval=4h` の場合は 1h 足を 4 本ずつ集約して 4h を生成する。
+ */
+export const fetchCandles = async (
+  symbol: string,
+  interval: Interval,
+  from: Date,
+  to: Date,
+): Promise<FetchedCandle[]> => {
+  const yfInterval = INTERVAL_MAP[interval];
+  const result = await yf.chart(symbol, {
+    period1: from,
+    period2: to,
+    interval: yfInterval,
+  });
+
+  const bars = (result.quotes ?? []).filter(
+    (q): q is NonNullBar =>
+      q.date != null && q.open != null && q.high != null && q.low != null && q.close != null,
+  );
+
+  const normalized = bars.map((b) => ({
+    time: Math.floor(b.date.getTime() / 1000),
+    open: b.open,
+    high: b.high,
+    low: b.low,
+    close: b.close,
+    volume: b.volume ?? 0,
+  }));
+
+  if (interval === "4h") {
+    return aggregate4h(normalized);
+  }
+  return normalized;
+};
+
+const aggregate4h = (bars: FetchedCandle[]): FetchedCandle[] => {
+  const buckets = new Map<number, FetchedCandle[]>();
+  for (const b of bars) {
+    const bucketStart = Math.floor(b.time / (4 * 3600)) * (4 * 3600);
+    const arr = buckets.get(bucketStart);
+    if (arr) {
+      arr.push(b);
+    } else {
+      buckets.set(bucketStart, [b]);
+    }
+  }
+  const result: FetchedCandle[] = [];
+  for (const [bucketStart, group] of [...buckets.entries()].sort((a, b) => a[0] - b[0])) {
+    if (group.length === 0) continue;
+    result.push({
+      time: bucketStart,
+      open: group[0].open,
+      high: Math.max(...group.map((g) => g.high)),
+      low: Math.min(...group.map((g) => g.low)),
+      close: group[group.length - 1].close,
+      volume: group.reduce((sum, g) => sum + g.volume, 0),
+    });
+  }
+  return result;
+};


### PR DESCRIPTION
## Summary

`docs/02-data-collection.md` を実装。**Yahoo Finance** ベースの OHLCV 自動取得 API を 4 本追加し、Phase D で構築した PostgreSQL `Candle` テーブルへ upsert。

## 主な変更

### パッケージ
- `yahoo-finance2` ^3.14.0 を追加

### ユーティリティ

#### `src/utils/yahooFinance.ts`
- `new YahooFinance()` インスタンスで `chart()` API を呼び出し
- **`interval=4h` は Yahoo が直接非対応**のため、`1h` を取得して 4 本ずつ集約
- `null` を含むバーは除外、Unix 秒に正規化
- 対応 interval: `5m` / `15m` / `1h` / `4h` / `1d`

#### `src/utils/dataIngestion.ts`
- `ingestSymbol(symbol, interval, from, to)` で取得 → `prisma.candle.upsert` で保存
- `(chartMasterId, interval, time)` ユニーク制約で冪等
- 戻り値：`{ inserted, updated, total }`

### API エンドポイント

| ルート | 用途 |
|------|------|
| `POST /api/data/fetch` | 単一シンボル + interval を取得・保存 |
| `POST /api/data/fetch/batch` | 全マスタ（or `assetType` フィルタ）を一括取得 |
| `GET /api/data/status` | シンボル × interval ごとの件数・最終時刻 |
| `GET /api/masters` | ChartMaster 一覧（`assetType` フィルタ可） |

`/api/data/fetch/batch` のデフォルト interval：
- **FX**: `["1h", "4h"]`
- **STOCK**: `["1d", "1h"]`

#### サンプルリクエスト

```bash
# 単一銘柄取得
curl -X POST http://localhost:3000/api/data/fetch \
  -H "Content-Type: application/json" \
  -d '{"symbol":"7203.T","interval":"1d","from":"2024-01-01"}'

# 一括取得（FX のみ）
curl -X POST http://localhost:3000/api/data/fetch/batch \
  -H "Content-Type: application/json" \
  -d '{"assetType":"FX","from":"2024-12-01"}'

# 状態確認
curl http://localhost:3000/api/data/status
```

## 検証結果

- `npm run build`：**`✓ Compiled successfully in 3.2s`**、新ルート 4 本含めて Static 11/11 + Dynamic 9 ルート
- `npm run lint`：エラー 0、警告 19（既存）

## 既知の制約・残件

- Yahoo の `5m` / `15m` は履歴期間が短い（直近 60 日程度）。長期履歴が必要な場合は `1d` 中心に運用
- 大量銘柄 batch 取得時のレート制限対策（指数バックオフ）は後追い
- スケジュール実行（Vercel Cron / GitHub Actions）は別タスク
- UI からの取得トリガ・進捗表示は別タスク（仕様 04 マルチアセット UI と同時に実装予定）

## Test plan

- [ ] Postgres を `docker compose up postgres` で起動
- [ ] `npm run db:migrate` でマイグレーション、`npm run db:seed` でマスタ投入
- [ ] `npm run dev` で起動、`POST /api/data/fetch` に `{symbol:"7203.T", interval:"1d"}` を送って `inserted` が返ること
- [ ] `GET /api/data/status` で取得結果が確認できること
- [ ] `GET /api/masters` で 12 銘柄（FX 5 + 株 7）が返ること
- [ ] `POST /api/data/fetch/batch` で複数銘柄が逐次取得できること

## 次のステップ

仕様 04（マルチアセット UI）または 03（自動ラベリング）の実装に進めます。

https://claude.ai/code/session_01AGh3ja6X8ZsgX3U6MyBgGZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGh3ja6X8ZsgX3U6MyBgGZ)_