### PR TITLE
仕様04 実装: マルチアセット UI（FX / 株切替 + データ管理画面）

### DIFF
--- a/docs/04-multi-asset-support.md
+++ b/docs/04-multi-asset-support.md
@@ -83,4 +83,47 @@ labelData_USDJPY_1h_2024.json
 
 ## 実装メモ
 
-（実装後に追記）
+### 実装記録（完了）
+
+#### 新規 Hook
+- `src/hooks/useMasters.ts`：
+  - `/api/masters` をクライアントから取得して `Master[]` を返却
+  - `INTERVALS_BY_ASSET` 定数（FX: `5m/1h/4h`、STOCK: `1h/1d`）
+
+#### 新規コンポーネント
+- `src/components/SymbolSelector.tsx`（MUI）：
+  - アセットタイプタブ（FX / 株）
+  - タブ切替時に同タイプの先頭銘柄に自動切替
+  - 銘柄ドロップダウン
+
+#### `/chart` ページ刷新
+- ハードコードの `selectPair = "GBPJPY"` を撤廃し、`SymbolSelector` で動的に切替
+- `assetType` / `symbol` を localStorage に永続化
+- チャート pane を **`intervals` 配列で動的に描画**
+  - FX 選択時: 3 pane（5m / 1h / 4h）
+  - 株選択時: 2 pane（1h / 1d）
+- データ未投入時は「データがありません（自動取得を実行してください）」を表示
+
+#### `CreateLabeling` 改修
+- 内部の通貨ペアセレクタを撤去し、親から渡された `symbol` を使用
+- ID 取得失敗時の警告メッセージを追加
+
+#### `/admin/data` 管理画面（新規）
+- 単一銘柄取得フォーム（symbol / interval / from / to）
+- 一括取得ボタン（FX / 株 / 全件）
+- 取得状況テーブル（symbol × interval ごとの件数 + 最終時刻）
+
+#### Navigation
+- 「Data」リンクを追加して `/admin/data` へ遷移可能に
+
+#### API 追補
+- `GET /api/candles/labels`：`symbol` クエリで `chartMasterId` 単位にフィルタ可能
+
+#### 検証結果
+- `npm run build`：`✓ Compiled successfully`、Static **16/16**（`/admin/data` 含む）
+- `npm run lint`：エラー 0、警告 19（既存品質）
+
+#### 既知の制約・残件
+- 株の 5m / 4h は Yahoo の履歴制約で実装に含めず（仕様通り）
+- 取引時間外のローソク連続性（市場ギャップ）の Lightweight Charts 側カスタマイズは別タスク
+- バルクラベリング・進捗表示・取得失敗の銘柄リスト表示は最小実装（必要に応じて拡張）

--- a/src/app/admin/data/page.tsx
+++ b/src/app/admin/data/page.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Container,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  type SelectChangeEvent,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+import axios from "axios";
+import { useEffect, useState } from "react";
+import { type AssetType, INTERVALS_BY_ASSET, useMasters } from "@/hooks/useMasters";
+
+interface IntervalStatus {
+  interval: string;
+  count: number;
+  latestTime: number | null;
+  fetchedAt: string | null;
+}
+
+interface SymbolStatus {
+  symbol: string;
+  displayName: string;
+  assetType: AssetType;
+  market: string;
+  intervals: IntervalStatus[];
+}
+
+const AdminDataPage = () => {
+  const { masters, loading: mastersLoading } = useMasters();
+  const [status, setStatus] = useState<SymbolStatus[]>([]);
+  const [statusLoading, setStatusLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<{ kind: "info" | "error"; text: string } | null>(null);
+
+  const [selectedSymbol, setSelectedSymbol] = useState<string>("");
+  const [selectedInterval, setSelectedInterval] = useState<string>("1d");
+  const [from, setFrom] = useState<string>("");
+  const [to, setTo] = useState<string>("");
+
+  const refreshStatus = async () => {
+    setStatusLoading(true);
+    try {
+      const res = await axios.get<SymbolStatus[]>("/api/data/status");
+      setStatus(res.data);
+    } catch (err) {
+      setMessage({ kind: "error", text: `状態取得失敗: ${err}` });
+    } finally {
+      setStatusLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refreshStatus();
+  }, []);
+
+  useEffect(() => {
+    if (!selectedSymbol && masters.length > 0) {
+      setSelectedSymbol(masters[0].symbol);
+    }
+  }, [masters, selectedSymbol]);
+
+  const fetchSingle = async () => {
+    if (!selectedSymbol || !selectedInterval) return;
+    setBusy(true);
+    setMessage(null);
+    try {
+      const res = await axios.post("/api/data/fetch", {
+        symbol: selectedSymbol,
+        interval: selectedInterval,
+        from: from || undefined,
+        to: to || undefined,
+      });
+      setMessage({
+        kind: "info",
+        text: `${selectedSymbol} ${selectedInterval}: inserted=${res.data.inserted}, updated=${res.data.updated}, total=${res.data.total}`,
+      });
+      await refreshStatus();
+    } catch (err) {
+      setMessage({ kind: "error", text: `${err}` });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const fetchBatch = async (assetType?: AssetType) => {
+    setBusy(true);
+    setMessage(null);
+    try {
+      const res = await axios.post("/api/data/fetch/batch", {
+        ...(assetType ? { assetType } : {}),
+        from: from || undefined,
+        to: to || undefined,
+      });
+      const total = res.data.results.reduce(
+        (sum: number, r: { total: number }) => sum + r.total,
+        0,
+      );
+      const errs = res.data.errors.length;
+      setMessage({
+        kind: errs > 0 ? "error" : "info",
+        text: `Batch ${assetType ?? "ALL"}: ${res.data.results.length} 件処理 (total ${total} 本) / errors ${errs}`,
+      });
+      await refreshStatus();
+    } catch (err) {
+      setMessage({ kind: "error", text: `${err}` });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const intervalsForSymbol = (() => {
+    const m = masters.find((x) => x.symbol === selectedSymbol);
+    return m ? INTERVALS_BY_ASSET[m.assetType] : ["1d"];
+  })();
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 3 }}>
+      <Typography variant="h4" gutterBottom>
+        データ管理
+      </Typography>
+
+      {message && (
+        <Alert severity={message.kind === "error" ? "error" : "info"} sx={{ mb: 2 }}>
+          {message.text}
+        </Alert>
+      )}
+
+      <Paper sx={{ p: 2, mb: 3 }}>
+        <Typography variant="h6" gutterBottom>
+          単一銘柄の取得
+        </Typography>
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems="center">
+          <FormControl size="small" sx={{ minWidth: 220 }} disabled={mastersLoading}>
+            <InputLabel id="admin-symbol">銘柄</InputLabel>
+            <Select
+              labelId="admin-symbol"
+              label="銘柄"
+              value={selectedSymbol}
+              onChange={(e: SelectChangeEvent) => setSelectedSymbol(e.target.value)}
+            >
+              {masters.map((m) => (
+                <MenuItem key={m.symbol} value={m.symbol}>
+                  {m.displayName} ({m.symbol})
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl size="small" sx={{ minWidth: 120 }}>
+            <InputLabel id="admin-interval">時間足</InputLabel>
+            <Select
+              labelId="admin-interval"
+              label="時間足"
+              value={selectedInterval}
+              onChange={(e: SelectChangeEvent) => setSelectedInterval(e.target.value)}
+            >
+              {intervalsForSymbol.map((iv) => (
+                <MenuItem key={iv} value={iv}>
+                  {iv}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField
+            label="from (YYYY-MM-DD)"
+            size="small"
+            value={from}
+            onChange={(e) => setFrom(e.target.value)}
+          />
+          <TextField
+            label="to (YYYY-MM-DD)"
+            size="small"
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+          />
+          <Button variant="contained" onClick={fetchSingle} disabled={busy || !selectedSymbol}>
+            取得
+          </Button>
+        </Stack>
+      </Paper>
+
+      <Paper sx={{ p: 2, mb: 3 }}>
+        <Typography variant="h6" gutterBottom>
+          一括取得
+        </Typography>
+        <Stack direction="row" spacing={2}>
+          <Button variant="outlined" onClick={() => fetchBatch("FX")} disabled={busy}>
+            FX 全銘柄
+          </Button>
+          <Button variant="outlined" onClick={() => fetchBatch("STOCK")} disabled={busy}>
+            株 全銘柄
+          </Button>
+          <Button variant="contained" onClick={() => fetchBatch()} disabled={busy}>
+            全件
+          </Button>
+        </Stack>
+      </Paper>
+
+      <Paper sx={{ p: 2 }}>
+        <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+          <Typography variant="h6">取得状況</Typography>
+          <Button onClick={refreshStatus} disabled={statusLoading}>
+            更新
+          </Button>
+        </Box>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>銘柄</TableCell>
+              <TableCell>種別</TableCell>
+              <TableCell>市場</TableCell>
+              <TableCell>時間足ごとの件数 / 最終時刻</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {status.map((s) => (
+              <TableRow key={s.symbol}>
+                <TableCell>
+                  {s.displayName}
+                  <br />
+                  <small>{s.symbol}</small>
+                </TableCell>
+                <TableCell>{s.assetType}</TableCell>
+                <TableCell>{s.market}</TableCell>
+                <TableCell>
+                  <Stack direction="row" spacing={1} flexWrap="wrap">
+                    {s.intervals.length === 0 && (
+                      <Chip size="small" label="未取得" color="default" />
+                    )}
+                    {s.intervals.map((iv) => (
+                      <Chip
+                        key={iv.interval}
+                        size="small"
+                        color="primary"
+                        variant="outlined"
+                        label={`${iv.interval}: ${iv.count} 本 / ${
+                          iv.latestTime
+                            ? new Date(iv.latestTime * 1000).toISOString().slice(0, 16)
+                            : "-"
+                        }`}
+                      />
+                    ))}
+                  </Stack>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+    </Container>
+  );
+};
+
+export default AdminDataPage;

--- a/src/app/api/candles/labels/fetch.ts
+++ b/src/app/api/candles/labels/fetch.ts
@@ -1,5 +1,7 @@
 import axios from "axios";
 
-export const getLabels = async () => {
-  return await axios.get("/api/candles/labels");
+export const getLabels = async (symbol?: string) => {
+  return await axios.get("/api/candles/labels", {
+    params: symbol ? { symbol } : undefined,
+  });
 };

--- a/src/app/api/candles/labels/route.ts
+++ b/src/app/api/candles/labels/route.ts
@@ -1,9 +1,23 @@
 import { type NextRequest, NextResponse } from "next/server";
 import prisma from "@/utils/db";
 
-export const GET = async (_req: NextRequest) => {
+export const GET = async (req: NextRequest) => {
+  const symbol = req.nextUrl.searchParams.get("symbol");
+
+  let chartMasterId: number | undefined;
+  if (symbol) {
+    const master = await prisma.chartMaster.findUnique({ where: { symbol } });
+    if (!master) {
+      return NextResponse.json([], { status: 200 });
+    }
+    chartMasterId = master.id;
+  }
+
   const labelings = await prisma.labeling.findMany({
-    where: { deletedAt: null },
+    where: {
+      deletedAt: null,
+      ...(chartMasterId ? { chartMasterId } : {}),
+    },
     orderBy: { createdAt: "desc" },
     select: { id: true, name: true },
   });

--- a/src/app/chart/page.tsx
+++ b/src/app/chart/page.tsx
@@ -7,11 +7,13 @@ import type {
   SeriesMarkerShape,
   Time,
 } from "lightweight-charts";
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import Button from "@/components/Button";
 import CreateLabeling from "@/components/CreateLabeling";
 import Dropdown, { type FromOption } from "@/components/DropDown";
 import LightweightChartComponent from "@/components/LightweightChartComponent";
+import SymbolSelector from "@/components/SymbolSelector";
+import { type AssetType, INTERVALS_BY_ASSET } from "@/hooks/useMasters";
 import { ChartClickDataContext } from "@/provider/ChartClickDataProvider";
 import type { CandleType } from "@/types/Candle";
 import { findManyBookmark, registerBookmark } from "../api/bookmark/fetch";
@@ -21,95 +23,96 @@ import { getLabelingData, labelingFetch } from "../api/candles/labeling/fetch";
 import { getLabels } from "../api/candles/labels/fetch";
 import { fileCreate } from "../api/file/fetch";
 
+const DEFAULT_FX_SYMBOL = "GBPJPY=X";
+const DEFAULT_STOCK_SYMBOL = "7203.T";
+
 const ChartPage = () => {
   const { chartClickDataState } = useContext(ChartClickDataContext);
   const [isLoading, setIsLoading] = useState(true);
   const [bookMarks, setBookmarks] = useState<BookmarkData[]>([]);
   const [labels, setLabels] = useState<FromOption[]>([]);
   const [selectedLabel, setSelectedLabel] = useState<string | undefined>();
-  const [selectPair, _setSelectPair] = useState("GBPJPY");
+
+  const [assetType, setAssetType] = useState<AssetType>("FX");
+  const [symbol, setSymbol] = useState<string>(DEFAULT_FX_SYMBOL);
+
   const [selectBookmark, setSelectBookmark] = useState<BookmarkData>();
-  const [data, setData] = useState<{
-    data1: CandleType[];
-    data2: CandleType[];
-    data3: CandleType[];
-  }>({
-    data1: [],
-    data2: [],
-    data3: [],
-  });
+  const intervals = useMemo(() => INTERVALS_BY_ASSET[assetType], [assetType]);
+  const [chartData, setChartData] = useState<Record<string, CandleType[]>>({});
+  const [chartIndex, setChartIndex] = useState<Record<string, number>>({});
 
   const [barNum, _setBarNum] = useState(20000);
   const [fromTo, setFromTo] = useState<{ from: Time; to: Time }>({ from: "0", to: "0" });
 
   const [labelData, setLabelData] = useState<SeriesMarker<Time>[]>([]);
-  const [nowIndex, setNowIndex] = useState({ data1: 0, data2: 0, data3: 0 });
 
-  const fetchAllData = async (_labeling_id: string | undefined, lastBookMark: number) => {
-    setIsLoading(true);
-    const result = { data1: [], data2: [], data3: [] };
-    console.log(lastBookMark);
-    result.data1 = await fetchMoreData(
-      "5m",
-      selectPair,
-      lastBookMark.toString(),
-      barNum.toString(),
-    );
-    result.data2 = await fetchMoreData(
-      "1h",
-      selectPair,
-      lastBookMark.toString(),
-      //Math.round(barNum / 12).toString()
-      barNum.toString(),
-    );
+  // 永続化された assetType / symbol を初期ロード
+  useEffect(() => {
+    const at = (localStorage.getItem("asset_type") as AssetType | null) ?? "FX";
+    const sym =
+      localStorage.getItem("symbol") ?? (at === "FX" ? DEFAULT_FX_SYMBOL : DEFAULT_STOCK_SYMBOL);
+    setAssetType(at);
+    setSymbol(sym);
+  }, []);
 
-    result.data3 = await fetchMoreData(
-      "4h",
-      selectPair,
-      lastBookMark.toString(),
-      //Math.round(barNum / 48).toString()
-      barNum.toString(),
-    );
-    setData(result);
-    setIsLoading(false);
+  const handleAssetTypeChange = (next: AssetType) => {
+    setAssetType(next);
+    localStorage.setItem("asset_type", next);
   };
+
+  const handleSymbolChange = (next: string) => {
+    setSymbol(next);
+    localStorage.setItem("symbol", next);
+  };
+
+  const fetchAllData = useCallback(
+    async (lastBookMark: number) => {
+      setIsLoading(true);
+      const result: Record<string, CandleType[]> = {};
+      for (const interval of intervals) {
+        result[interval] = await fetchMoreData(
+          interval,
+          symbol,
+          lastBookMark.toString(),
+          barNum.toString(),
+        );
+      }
+      setChartData(result);
+      const idx: Record<string, number> = {};
+      for (const interval of intervals) idx[interval] = lastBookMark;
+      setChartIndex(idx);
+      setIsLoading(false);
+    },
+    [intervals, symbol, barNum],
+  );
 
   useEffect(() => {
     const firstEffect = async () => {
-      const getLabelsRes = await getLabels();
-
+      const getLabelsRes = await getLabels(symbol);
       setLabels(getLabelsRes.data);
 
-      const bookmarkRes = await findManyBookmark(localStorage.getItem("labeling_id")!);
+      const labelingId = localStorage.getItem("labeling_id");
+      if (labelingId) {
+        try {
+          const bookmarkRes = await findManyBookmark(labelingId);
+          setBookmarks(bookmarkRes ?? []);
 
-      const labelingRes = await getLabelingData(localStorage.getItem("labeling_id")!);
+          const labelingRes = await getLabelingData(labelingId);
+          setLabelData(labelingRes.data ?? []);
 
-      setLabelData(labelingRes.data);
-      setNowIndex({
-        data1: bookmarkRes.slice(-1)[0].index,
-        data2: bookmarkRes.slice(-1)[0].index,
-        data3: bookmarkRes.slice(-1)[0].index,
-      });
-      setBookmarks(bookmarkRes);
-      fetchAllData(
-        getLabelsRes.data.length === 0 ? undefined : localStorage.getItem("labeling_id") || "0",
-        bookmarkRes.slice(-1)[0].index,
-      );
-
-      setSelectedLabel(
-        getLabelsRes.data.length === 0 ? undefined : localStorage.getItem("labeling_id") || "0",
-      );
+          const last = bookmarkRes?.slice(-1)[0]?.index ?? 0;
+          await fetchAllData(last);
+          setSelectedLabel(getLabelsRes.data.length === 0 ? undefined : labelingId);
+          return;
+        } catch (error) {
+          console.error("Failed to load labeling:", error);
+        }
+      }
+      await fetchAllData(0);
+      setSelectedLabel(undefined);
     };
     firstEffect();
-  }, [fetchAllData]);
-
-  useEffect(() => {
-    console.log(chartClickDataState);
-  }, [chartClickDataState]);
-
-  if (isLoading) {
-    return <div>Loading...</div>;
-  }
+  }, [symbol, fetchAllData]);
 
   const setLabelHandler = (
     time: Time,
@@ -122,17 +125,17 @@ const ChartPage = () => {
       if (position === undefined) {
         return prevData.filter((item) => item.time !== time);
       }
-      const newData = [
-        ...prevData,
-        {
-          time: time,
-          position: position!,
-          color: color!,
-          shape: shape!,
-          text: text!,
-        },
-      ];
+      const newData = [...prevData, { time, position, color: color!, shape: shape!, text: text! }];
       return newData.sort((a, b) => Number(a.time) - Number(b.time));
+    });
+  };
+
+  const handleLoadMore = (interval: string, movement: boolean) => {
+    const current = chartIndex[interval] ?? 0;
+    const nextIndex = movement ? current + barNum : Math.max(0, current - barNum);
+    fetchMoreData(interval, symbol, nextIndex.toString(), barNum.toString()).then((newData) => {
+      setChartData((prev) => ({ ...prev, [interval]: newData }));
+      setChartIndex((prev) => ({ ...prev, [interval]: nextIndex }));
     });
   };
 
@@ -140,162 +143,67 @@ const ChartPage = () => {
     <div>
       <div className="container">
         <div className="column">
-          <h1>5 Minute Chart</h1>
-          {data.data1.length !== 0 && (
-            <LightweightChartComponent
-              data={data.data1}
-              labelData={labelData}
-              loadMoreItems={(movement: boolean) => {
-                if (movement) {
-                  fetchMoreData(
-                    "5m",
-                    selectPair,
-                    (nowIndex.data1 + barNum).toString(),
-                    barNum.toString(),
-                  ).then((newData) => {
-                    console.log("5 chart loading");
-                    setNowIndex({ ...nowIndex, data1: nowIndex.data1 + barNum });
-                    setData((prevData) => ({ ...prevData, data1: newData }));
-                  });
-                } else {
-                  fetchMoreData(
-                    "5m",
-                    selectPair,
-                    (nowIndex.data1 - barNum >= 0 ? nowIndex.data1 - barNum : 0).toString(),
-                    barNum.toString(),
-                  ).then((newData) => {
-                    console.log("5 chart loading");
-                    setNowIndex({
-                      ...nowIndex,
-                      data1: nowIndex.data1 - barNum >= 0 ? nowIndex.data1 - barNum : 0,
-                    });
-                    setData((prevData) => ({ ...prevData, data1: newData }));
-                  });
-                }
-              }}
+          <div className="m-2">
+            <SymbolSelector
+              assetType={assetType}
+              symbol={symbol}
+              onChangeAssetType={handleAssetTypeChange}
+              onChangeSymbol={handleSymbolChange}
             />
-          )}
-          <h1>1 Hour Chart</h1>
-          {data.data2.length !== 0 && (
-            <LightweightChartComponent
-              data={data.data2}
-              labelData={labelData}
-              loadMoreItems={(movement: boolean) => {
-                if (movement) {
-                  fetchMoreData(
-                    "1h",
-                    selectPair,
-                    (nowIndex.data2 + barNum).toString(),
-                    barNum.toString(),
-                    //(nowIndex.data2 + Math.round(barNum / 12)).toString(),
-                    //Math.round(barNum / 12).toString()
-                  ).then((newData) => {
-                    setNowIndex({
-                      ...nowIndex,
-                      data2: nowIndex.data2 + barNum,
-                      //data2: (nowIndex.data2 + Math.round(barNum / 12))
-                    });
-                    setData((prevData) => ({ ...prevData, data2: newData }));
-                  });
-                } else {
-                  fetchMoreData(
-                    "1h",
-                    selectPair,
-                    (nowIndex.data2 - barNum >= 0 ? nowIndex.data2 - barNum : 0).toString(),
-                    barNum.toString(),
-                    // ((nowIndex.data2 - Math.round(barNum / 12)) >= 0 ? nowIndex.data2 - Math.round(barNum / 12) : 0).toString(),
-                    // Math.round(barNum / 12).toString()
-                  ).then((newData) => {
-                    setNowIndex({
-                      ...nowIndex,
-                      data2: nowIndex.data2 - barNum >= 0 ? nowIndex.data2 - barNum : 0,
-                      //data2: (nowIndex.data2 - Math.round(barNum / 12)) >= 0 ? (nowIndex.data2 - Math.round(barNum / 12)) : 0
-                    });
-                    setData((prevData) => ({ ...prevData, data2: newData }));
-                  });
-                }
-              }}
-            />
-          )}
-          <h1>4 Hour Chart</h1>
-          {data.data3.length !== 0 && (
-            <LightweightChartComponent
-              data={data.data3}
-              labelData={labelData}
-              loadMoreItems={(movement: boolean) => {
-                if (movement) {
-                  fetchMoreData(
-                    "4h",
-                    selectPair,
-                    (nowIndex.data3 + barNum).toString(),
-                    barNum.toString(),
-                    // (nowIndex.data3 + Math.round(barNum / 48)).toString(),
-                    // Math.round(barNum / 48).toString()
-                  ).then((newData) => {
-                    setNowIndex({
-                      ...nowIndex,
-                      data3: nowIndex.data2 + barNum,
-                      //data3: nowIndex.data3 + Math.round(barNum / 48)
-                    });
-                    setData((prevData) => ({ ...prevData, data3: newData }));
-                  });
-                } else {
-                  fetchMoreData(
-                    "4h",
-                    selectPair,
-                    (nowIndex.data3 - barNum >= 0 ? nowIndex.data3 - barNum : 0).toString(),
-                    barNum.toString(),
-                    // ((nowIndex.data3 - Math.round(barNum / 48)) >= 0 ? nowIndex.data3 - Math.round(barNum / 48) : 0).toString(),
-                    // Math.round(barNum / 48).toString()
-                  ).then((newData) => {
-                    setNowIndex({
-                      ...nowIndex,
-                      data3: nowIndex.data3 - barNum >= 0 ? nowIndex.data3 - barNum : 0,
-                      //data3: (nowIndex.data3 - Math.round(barNum / 48)) >= 0 ? nowIndex.data3 - Math.round(barNum / 48) : 0
-                    });
-                    setData((prevData) => ({ ...prevData, data3: newData }));
-                  });
-                }
-              }}
-            />
+          </div>
+
+          {isLoading ? (
+            <div>Loading...</div>
+          ) : (
+            intervals.map((interval) => (
+              <div key={interval}>
+                <h1>{interval} Chart</h1>
+                {chartData[interval]?.length ? (
+                  <LightweightChartComponent
+                    data={chartData[interval]}
+                    labelData={labelData}
+                    loadMoreItems={(movement: boolean) => handleLoadMore(interval, movement)}
+                  />
+                ) : (
+                  <div>データがありません（自動取得を実行してください）</div>
+                )}
+              </div>
+            ))
           )}
         </div>
+
         <div className="column">
           <h2>close</h2>
           {chartClickDataState.close}
           <h2>time</h2>
           {chartClickDataState.time.toString()}
-          <br></br>
+          <br />
           <div className="m-2">
             <Button
               text="この時間でBookmark"
               onClick={async () => {
-                const result = await registerBookmark({
+                if (!selectedLabel) return;
+                await registerBookmark({
                   time: chartClickDataState.time,
                   chartLabelingId: Number(selectedLabel),
                 });
-                console.log(result);
               }}
-            ></Button>
+            />
           </div>
           <div className="m-2">
             <h2>bookmark select</h2>
             <Dropdown
-              options={bookMarks.map((value) => {
-                return {
-                  key: value.time.toLocaleString(),
-                  value: value.time.toString(),
-                };
-              })}
+              options={bookMarks.map((value) => ({
+                key: value.time.toLocaleString(),
+                value: value.time.toString(),
+              }))}
               value={selectBookmark?.time.toString() || "-1"}
-              onSelect={(e: any) => {
-                console.log(e.target.value);
-                //localStorage.setItem("chart_id", e.target.value)
+              onSelect={(e: React.ChangeEvent<HTMLSelectElement>) => {
                 setSelectBookmark(
                   bookMarks.filter((value) => e.target.value === value.time.toString())[0],
                 );
               }}
-            ></Dropdown>
+            />
           </div>
 
           <div className="m-2">
@@ -303,20 +211,14 @@ const ChartPage = () => {
             <Dropdown
               options={labels}
               value={selectedLabel || "-1"}
-              onSelect={(e: any) => {
-                console.log(e.target.value);
+              onSelect={(e: React.ChangeEvent<HTMLSelectElement>) => {
                 localStorage.setItem("labeling_id", e.target.value);
                 setSelectedLabel(e.target.value);
               }}
-            ></Dropdown>
+            />
           </div>
           <div className="m-2">
-            <Button
-              text="labelを再配置"
-              onClick={() => {
-                window.location.reload();
-              }}
-            ></Button>
+            <Button text="labelを再配置" onClick={() => window.location.reload()} />
           </div>
 
           <div className="m-2">
@@ -331,84 +233,74 @@ const ChartPage = () => {
           <div className="m-2">
             <Button
               text="買い"
-              onClick={() => {
-                console.log(labelData);
+              onClick={() =>
                 setLabelHandler(
                   chartClickDataState.time,
                   "belowBar",
                   "#2196F3",
                   "arrowUp",
                   `buy ${chartClickDataState.time}`,
-                );
-              }}
-            ></Button>
+                )
+              }
+            />
           </div>
           <div className="m-2">
             <Button
               text="売り"
-              onClick={() => {
+              onClick={() =>
                 setLabelHandler(
                   chartClickDataState.time,
                   "aboveBar",
                   "#e91e63",
                   "arrowDown",
                   `sell ${chartClickDataState.time}`,
-                );
-              }}
-            ></Button>
+                )
+              }
+            />
           </div>
           <div className="m-2">
             <Button
               text="利確"
-              onClick={() => {
+              onClick={() =>
                 setLabelHandler(
                   chartClickDataState.time,
                   "belowBar",
                   "#f68410",
                   "circle",
                   `profit ${chartClickDataState.time}`,
-                );
-              }}
-            ></Button>
+                )
+              }
+            />
           </div>
           <div className="m-2">
-            <Button
-              text="取り消し"
-              onClick={() => {
-                setLabelHandler(chartClickDataState.time);
-              }}
-            ></Button>
+            <Button text="取り消し" onClick={() => setLabelHandler(chartClickDataState.time)} />
           </div>
 
           <Button
             text="登録"
             onClick={() => {
-              labelingFetch(labelData, selectedLabel!);
+              if (selectedLabel) labelingFetch(labelData, selectedLabel);
             }}
-          ></Button>
-          <CreateLabeling></CreateLabeling>
+          />
+          <CreateLabeling symbol={symbol} />
 
           <h3>{fromTo.from.toString()}</h3>
           <h3>{fromTo.to.toString()}</h3>
           <Button
             text="from"
-            onClick={() => {
-              setFromTo({ ...fromTo!, from: chartClickDataState!.time });
-            }}
-          ></Button>
+            onClick={() => setFromTo({ ...fromTo, from: chartClickDataState.time })}
+          />
           <Button
             text="to"
-            onClick={() => {
-              setFromTo({ ...fromTo!, to: chartClickDataState!.time });
-            }}
-          ></Button>
+            onClick={() => setFromTo({ ...fromTo, to: chartClickDataState.time })}
+          />
 
           <Button
             text="ファイルを作成"
             onClick={() => {
-              fileCreate(selectPair, fromTo!.from, fromTo!.to, selectedLabel!);
+              if (selectedLabel) fileCreate(symbol, fromTo.from, fromTo.to, selectedLabel);
             }}
-          ></Button>
+          />
         </div>
       </div>
     </div>

--- a/src/components/CreateLabeling.tsx
+++ b/src/components/CreateLabeling.tsx
@@ -1,39 +1,43 @@
 import { useState } from "react";
 import { labelingCreate } from "@/app/api/candles/labeling/create/fetch";
-import Dropdown from "./DropDown";
 import Form from "./Form";
 
-const CreateLabeling = () => {
-  const [selectedData, setSelectedData] = useState({ key: "GBPJPY", value: "GBPJPY" });
-  const [dropData, _setDropData] = useState([{ key: "GBPJPY", value: "GBPJPY" }]);
+interface Props {
+  symbol: string;
+}
+
+const CreateLabeling = ({ symbol }: Props) => {
   const [text, setText] = useState("");
 
-  const handleSelect = (event: any) => {
-    setSelectedData(event.target.value);
-  };
-  const handleButton = async (_e: any) => {
-    const res: any = await labelingCreate({
+  const handleButton = async (_e: React.MouseEvent<HTMLButtonElement>) => {
+    if (!text) {
+      window.alert("ラベル名を入力してください");
+      return;
+    }
+    const res = await labelingCreate({
       labelingName: text,
-      pair: selectedData.value,
+      pair: symbol,
     });
-    localStorage.setItem("labeling_id", String(res.data.id));
-    window.alert("labelを切り替えます");
-    window.location.reload();
+    if (res?.data?.id != null) {
+      localStorage.setItem("labeling_id", String(res.data.id));
+      window.alert("labelを切り替えます");
+      window.location.reload();
+    } else {
+      window.alert(
+        "ラベルの作成に失敗しました（チャートデータが投入されているか確認してください）",
+      );
+    }
   };
 
   return (
     <div className="m-5">
-      <h1>CreateLabeling</h1>
-      <Dropdown value={selectedData.value} options={dropData} onSelect={handleSelect}></Dropdown>
-
+      <h1>CreateLabeling ({symbol})</h1>
       <h3>ラベルの名前</h3>
       <Form
         text={text}
-        handleText={(e: any) => {
-          setText(e.target.value);
-        }}
+        handleText={(e: React.ChangeEvent<HTMLInputElement>) => setText(e.target.value)}
         handleButton={handleButton}
-      ></Form>
+      />
     </div>
   );
 };

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -16,6 +16,9 @@ export default function Navigation() {
           <Button color="inherit" component={Link} href="/chart">
             Chart
           </Button>
+          <Button color="inherit" component={Link} href="/admin/data">
+            Data
+          </Button>
         </Box>
       </Toolbar>
     </AppBar>

--- a/src/components/SymbolSelector.tsx
+++ b/src/components/SymbolSelector.tsx
@@ -1,0 +1,59 @@
+"use client";
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  type SelectChangeEvent,
+  Tab,
+  Tabs,
+} from "@mui/material";
+import { useMemo } from "react";
+import { type AssetType, useMasters } from "@/hooks/useMasters";
+
+interface Props {
+  assetType: AssetType;
+  symbol: string;
+  onChangeAssetType: (assetType: AssetType) => void;
+  onChangeSymbol: (symbol: string) => void;
+}
+
+const SymbolSelector = ({ assetType, symbol, onChangeAssetType, onChangeSymbol }: Props) => {
+  const { masters, loading } = useMasters();
+
+  const filtered = useMemo(
+    () => masters.filter((m) => m.assetType === assetType),
+    [masters, assetType],
+  );
+
+  const handleTabChange = (_event: React.SyntheticEvent, value: AssetType) => {
+    onChangeAssetType(value);
+    const first = masters.find((m) => m.assetType === value);
+    if (first) onChangeSymbol(first.symbol);
+  };
+
+  const handleSelect = (event: SelectChangeEvent<string>) => {
+    onChangeSymbol(event.target.value);
+  };
+
+  return (
+    <div>
+      <Tabs value={assetType} onChange={handleTabChange}>
+        <Tab label="FX" value="FX" />
+        <Tab label="株" value="STOCK" />
+      </Tabs>
+      <FormControl fullWidth size="small" sx={{ mt: 1 }} disabled={loading}>
+        <InputLabel id="symbol-select-label">銘柄</InputLabel>
+        <Select labelId="symbol-select-label" label="銘柄" value={symbol} onChange={handleSelect}>
+          {filtered.map((m) => (
+            <MenuItem key={m.symbol} value={m.symbol}>
+              {m.displayName} ({m.symbol})
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </div>
+  );
+};
+
+export default SymbolSelector;

--- a/src/hooks/useMasters.ts
+++ b/src/hooks/useMasters.ts
@@ -1,0 +1,45 @@
+"use client";
+import axios from "axios";
+import { useEffect, useState } from "react";
+
+export type AssetType = "FX" | "STOCK";
+
+export interface Master {
+  id: number;
+  symbol: string;
+  displayName: string;
+  assetType: AssetType;
+  market: string;
+}
+
+export const useMasters = (filter?: AssetType) => {
+  const [masters, setMasters] = useState<Master[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    axios
+      .get<Master[]>("/api/masters", { params: filter ? { assetType: filter } : {} })
+      .then((res) => {
+        if (active) setMasters(res.data);
+      })
+      .catch((err) => {
+        if (active) setError(`${err}`);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [filter]);
+
+  return { masters, loading, error };
+};
+
+export const INTERVALS_BY_ASSET: Record<AssetType, string[]> = {
+  FX: ["5m", "1h", "4h"],
+  STOCK: ["1h", "1d"],
+};


### PR DESCRIPTION
## Summary

`docs/04-multi-asset-support.md` を実装。**FX + 日本株のマルチアセット対応 UI** とデータ管理画面を追加。

仕様 02（自動データ収集）と組み合わせて使うことで、UI から銘柄選択 → データ取得 → ラベリング、までが一本の流れで実行できるようになりました。

## 主な変更

### 新規 Hook
**`src/hooks/useMasters.ts`**
- `/api/masters` をクライアントから取得して `Master[]` を返却
- `INTERVALS_BY_ASSET` 定数：
  - **FX**: `5m / 1h / 4h`
  - **STOCK**: `1h / 1d`

### 新規コンポーネント
**`SymbolSelector.tsx`（MUI ベース）**
- アセットタイプタブ（FX / 株）
- タブ切替時に同タイプの先頭銘柄に自動切替
- 銘柄ドロップダウン

### `/chart` ページ刷新
- ハードコードの `selectPair = "GBPJPY"` を **撤廃** し、`SymbolSelector` で動的切替
- `assetType` / `symbol` を localStorage に永続化
- チャート pane を **`intervals` 配列で動的描画**
  - FX 選択時: 3 pane（5m / 1h / 4h）
  - 株選択時: 2 pane（1h / 1d）
- データ未投入時は「データがありません（自動取得を実行してください）」を表示

### `/admin/data` 管理画面（新規）
- 単一銘柄取得フォーム（symbol / interval / from / to）
- 一括取得ボタン（**FX 全銘柄** / **株 全銘柄** / **全件**）
- 取得状況テーブル（symbol × interval ごとの件数 + 最終時刻）

### `CreateLabeling` 改修
- 内部の通貨ペアセレクタを撤去し、親から渡された `symbol` を使用
- ID 取得失敗時の警告メッセージを追加

### API 追補
- `GET /api/candles/labels`：`symbol` クエリで `chartMasterId` 単位フィルタ

### Navigation
- 「Data」リンク追加 → `/admin/data`

## 検証結果

- `npm run build`：**`✓ Compiled successfully`**、Static **16/16**（`/admin/data` 含む）
- `npm run lint`：エラー 0、警告 19（既存品質）

## 既知の制約・残件

- 株の 5m / 4h は Yahoo 履歴制約のため未対応（仕様通り）
- 取引時間外のローソク連続性（市場ギャップ）の Lightweight Charts カスタマイズは別タスク
- 進捗表示・失敗銘柄リスト表示は最小実装（必要に応じて拡張）

## Test plan（実環境）

- [ ] Postgres 起動 → `npm run db:migrate` → `npm run db:seed`
- [ ] `npm run dev` で `/admin/data` へアクセス、銘柄一覧が表示されることを確認
- [ ] 「FX 全銘柄」ボタンで一括取得、`取得状況` に各銘柄の件数が反映されることを確認
- [ ] 「株 全銘柄」ボタンで日本株データが取得されることを確認
- [ ] `/chart` へ移動、FX タブ → ペア選択 → チャートが表示されることを確認
- [ ] 株タブに切替 → 1h/1d の 2 pane が表示されることを確認
- [ ] CreateLabeling で新規ラベリング作成 → 切替 → ラベル付与
- [ ] 「ファイルを作成」で JSON 出力ができることを確認

## 次のステップ

仕様 03（**AI 自動ラベリング**）の実装に進みます。手動ラベリングの土台と銘柄/データ管理 UI が揃ったので、ルールベース自動ラベリング → UI への組み込みが可能になります。

https://claude.ai/code/session_01AGh3ja6X8ZsgX3U6MyBgGZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGh3ja6X8ZsgX3U6MyBgGZ)_