### PR TITLE
仕様03 実装 (Phase1): ルールベース自動ラベリング (SMA cross + RSI)

### DIFF
--- a/docs/03-auto-labeling.md
+++ b/docs/03-auto-labeling.md
@@ -142,4 +142,55 @@ src/lib/labeling/
 
 ## 実装メモ
 
-（実装後に追記）
+### Phase 1（ルールベース）実装記録（完了）
+
+#### モジュール構成
+```
+src/lib/labeling/
+├── index.ts                    # 公開エントリ
+├── types.ts                    # 型 + デフォルト config
+├── runner.ts                   # Prisma → ルール実行 → 結果
+├── strategies/
+│   └── ruleBased.ts            # SMA × RSI + 利確
+└── indicators/
+    ├── sma.ts
+    └── rsi.ts
+```
+
+#### インジケータ
+- `sma(values, period)`：シンプル移動平均、期間未満は `null`
+- `rsi(values, period)`：Wilder smoothing 版、期間+1 未満は `null`
+
+#### ルール（`labelByRules`）
+- SMA(short) が SMA(long) を上抜け **かつ** RSI < `rsiUpperBound` → **買い**
+- SMA(short) が SMA(long) を下抜け **かつ** RSI > `rsiLowerBound` → **売り**
+- ポジション保有中に `takeProfitPct` 到達 → **利確**
+- 反対シグナル発生時、保有ポジを **利確** で閉じてから新シグナルを置く
+- デフォルト：FX `0.5%`、株 `2.0%`
+
+#### API エンドポイント
+
+| ルート | 用途 |
+|------|------|
+| `POST /api/labeling/auto/preview` | DB 保存せず結果のみ返却（UI プレビュー） |
+| `POST /api/labeling/auto` | 結果を `Labeling.markers` に反映、`AutoLabelRun` を記録 |
+
+`auto` の `overwrite=false`（デフォルト）時は既存マーカーとマージし、同一時刻は後勝ちで上書き。
+
+#### UI 統合
+- `src/components/AutoLabelingPanel.tsx`（MUI）：
+  - 時間足セレクタ（asset type に応じた候補）
+  - 短期/長期 SMA、RSI 期間、利確 % のテキスト入力
+  - 上書きチェックボックス
+  - **プレビュー** ボタン → 件数を Alert 表示
+  - **ラベルに反映** ボタン → 適用後ページリロード
+- `/chart` の右カラム「登録」ボタン直下に組み込み
+
+#### 検証結果
+- `npm run build`：`✓ Compiled successfully`、Static **18/18**
+- `npm run lint`：エラー 0、警告 19（既存）
+
+#### 既知の制約・残件
+- Phase 2（LLM 補助）と Phase 3（ML モデル）は別タスクで段階的に実装
+- 自動ラベリングのバックテスト指標（勝率・PF）算出 UI は未実装
+- 大量データへの最適化（`createMany` での bulk insert / Prisma raw query）は必要に応じて追加

--- a/src/app/api/labeling/auto/preview/route.ts
+++ b/src/app/api/labeling/auto/preview/route.ts
@@ -1,0 +1,45 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { runRuleBasedLabeling } from "@/lib/labeling/runner";
+import type { RuleBasedConfig } from "@/lib/labeling/types";
+
+interface PreviewRequest {
+  symbol: string;
+  interval: string;
+  from?: string;
+  to?: string;
+  config?: Partial<RuleBasedConfig>;
+}
+
+export const POST = async (req: NextRequest) => {
+  let body: PreviewRequest;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+  if (!body.symbol || !body.interval) {
+    return NextResponse.json({ error: "symbol and interval are required" }, { status: 400 });
+  }
+
+  try {
+    const ctx = await runRuleBasedLabeling({
+      symbol: body.symbol,
+      interval: body.interval,
+      from: body.from ? new Date(body.from) : undefined,
+      to: body.to ? new Date(body.to) : undefined,
+      config: body.config,
+    });
+    return NextResponse.json(
+      {
+        symbol: body.symbol,
+        interval: body.interval,
+        candleCount: ctx.candleCount,
+        config: ctx.effectiveConfig,
+        ...ctx.result,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    return NextResponse.json({ error: `${error}` }, { status: 500 });
+  }
+};

--- a/src/app/api/labeling/auto/route.ts
+++ b/src/app/api/labeling/auto/route.ts
@@ -1,0 +1,90 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { runRuleBasedLabeling } from "@/lib/labeling/runner";
+import type { RuleBasedConfig } from "@/lib/labeling/types";
+import prisma from "@/utils/db";
+
+interface AutoLabelRequest {
+  labelingId: number;
+  symbol: string;
+  interval: string;
+  from?: string;
+  to?: string;
+  overwrite?: boolean;
+  config?: Partial<RuleBasedConfig>;
+}
+
+export const POST = async (req: NextRequest) => {
+  let body: AutoLabelRequest;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+
+  if (!body.labelingId || !body.symbol || !body.interval) {
+    return NextResponse.json(
+      { error: "labelingId, symbol, interval are required" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const ctx = await runRuleBasedLabeling({
+      symbol: body.symbol,
+      interval: body.interval,
+      from: body.from ? new Date(body.from) : undefined,
+      to: body.to ? new Date(body.to) : undefined,
+      config: body.config,
+    });
+
+    const labeling = await prisma.labeling.findUnique({
+      where: { id: body.labelingId },
+    });
+    if (!labeling) {
+      return NextResponse.json({ error: "labeling not found" }, { status: 404 });
+    }
+
+    const existing = (labeling.markers as unknown as { time: number }[]) ?? [];
+    const merged = body.overwrite ? ctx.result.markers : [...existing, ...ctx.result.markers];
+
+    // 同一時刻の重複を除去（後勝ち）
+    const dedupMap = new Map<number, (typeof merged)[number]>();
+    for (const m of merged) dedupMap.set(m.time, m);
+    const finalMarkers = [...dedupMap.values()].sort((a, b) => a.time - b.time);
+
+    await prisma.$transaction([
+      prisma.labeling.update({
+        where: { id: body.labelingId },
+        data: {
+          markers: finalMarkers as object,
+          source: "auto-rule",
+        },
+      }),
+      prisma.autoLabelRun.create({
+        data: {
+          labelingId: body.labelingId,
+          strategy: "rule-based",
+          config: ctx.effectiveConfig as object,
+          buyCount: ctx.result.counts.buy,
+          sellCount: ctx.result.counts.sell,
+          takeProfitCount: ctx.result.counts.takeProfit,
+          noneCount: ctx.result.counts.none,
+        },
+      }),
+    ]);
+
+    return NextResponse.json(
+      {
+        symbol: body.symbol,
+        interval: body.interval,
+        candleCount: ctx.candleCount,
+        markersAdded: ctx.result.markers.length,
+        totalMarkers: finalMarkers.length,
+        counts: ctx.result.counts,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    return NextResponse.json({ error: `${error}` }, { status: 500 });
+  }
+};

--- a/src/app/chart/page.tsx
+++ b/src/app/chart/page.tsx
@@ -8,6 +8,7 @@ import type {
   Time,
 } from "lightweight-charts";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import AutoLabelingPanel from "@/components/AutoLabelingPanel";
 import Button from "@/components/Button";
 import CreateLabeling from "@/components/CreateLabeling";
 import Dropdown, { type FromOption } from "@/components/DropDown";
@@ -281,6 +282,12 @@ const ChartPage = () => {
             onClick={() => {
               if (selectedLabel) labelingFetch(labelData, selectedLabel);
             }}
+          />
+          <AutoLabelingPanel
+            symbol={symbol}
+            assetType={assetType}
+            labelingId={selectedLabel}
+            onApplied={() => window.location.reload()}
           />
           <CreateLabeling symbol={symbol} />
 

--- a/src/components/AutoLabelingPanel.tsx
+++ b/src/components/AutoLabelingPanel.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Collapse,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  type SelectChangeEvent,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import axios from "axios";
+import { useState } from "react";
+import { INTERVALS_BY_ASSET } from "@/hooks/useMasters";
+
+interface PreviewCounts {
+  buy: number;
+  sell: number;
+  takeProfit: number;
+  none: number;
+}
+
+interface PreviewResponse {
+  symbol: string;
+  interval: string;
+  candleCount: number;
+  counts: PreviewCounts;
+  markers: { time: number; label: number }[];
+}
+
+interface Props {
+  symbol: string;
+  assetType: "FX" | "STOCK";
+  labelingId?: string;
+  onApplied?: () => void;
+}
+
+const AutoLabelingPanel = ({ symbol, assetType, labelingId, onApplied }: Props) => {
+  const intervals = INTERVALS_BY_ASSET[assetType];
+  const [interval, setInterval] = useState<string>(intervals[0]);
+  const [shortPeriod, setShortPeriod] = useState(5);
+  const [longPeriod, setLongPeriod] = useState(20);
+  const [rsiPeriod, setRsiPeriod] = useState(14);
+  const [takeProfitPct, setTakeProfitPct] = useState(assetType === "STOCK" ? 0.02 : 0.005);
+  const [overwrite, setOverwrite] = useState(false);
+  const [preview, setPreview] = useState<PreviewResponse | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const config = {
+    shortPeriod,
+    longPeriod,
+    rsiPeriod,
+    takeProfitPct,
+  };
+
+  const runPreview = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await axios.post<PreviewResponse>("/api/labeling/auto/preview", {
+        symbol,
+        interval,
+        config,
+      });
+      setPreview(res.data);
+    } catch (err) {
+      setError(`${err}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const apply = async () => {
+    if (!labelingId) {
+      setError("ラベリングを先に選択してください");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await axios.post("/api/labeling/auto", {
+        labelingId: Number(labelingId),
+        symbol,
+        interval,
+        config,
+        overwrite,
+      });
+      onApplied?.();
+    } catch (err) {
+      setError(`${err}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Paper sx={{ p: 2, mb: 2 }}>
+      <Typography variant="h6">自動ラベリング (rule-based)</Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+        SMA({shortPeriod}/{longPeriod}) クロス + RSI({rsiPeriod}) で買い/売り、利確 ±
+        {(takeProfitPct * 100).toFixed(2)}%
+      </Typography>
+
+      <Stack spacing={1.5}>
+        <FormControl size="small" fullWidth>
+          <InputLabel id="auto-interval">時間足</InputLabel>
+          <Select
+            labelId="auto-interval"
+            label="時間足"
+            value={interval}
+            onChange={(e: SelectChangeEvent) => setInterval(e.target.value)}
+          >
+            {intervals.map((iv) => (
+              <MenuItem key={iv} value={iv}>
+                {iv}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <Stack direction="row" spacing={1}>
+          <TextField
+            size="small"
+            type="number"
+            label="短期SMA"
+            value={shortPeriod}
+            onChange={(e) => setShortPeriod(Number(e.target.value))}
+          />
+          <TextField
+            size="small"
+            type="number"
+            label="長期SMA"
+            value={longPeriod}
+            onChange={(e) => setLongPeriod(Number(e.target.value))}
+          />
+          <TextField
+            size="small"
+            type="number"
+            label="RSI期間"
+            value={rsiPeriod}
+            onChange={(e) => setRsiPeriod(Number(e.target.value))}
+          />
+        </Stack>
+
+        <TextField
+          size="small"
+          type="number"
+          label="利確 % (0.005 = 0.5%)"
+          inputProps={{ step: 0.001 }}
+          value={takeProfitPct}
+          onChange={(e) => setTakeProfitPct(Number(e.target.value))}
+        />
+
+        <FormControlLabel
+          control={
+            <Checkbox checked={overwrite} onChange={(e) => setOverwrite(e.target.checked)} />
+          }
+          label="既存ラベルを上書き（デフォルトはマージ）"
+        />
+
+        <Stack direction="row" spacing={1}>
+          <Button variant="outlined" onClick={runPreview} disabled={busy}>
+            プレビュー
+          </Button>
+          <Button variant="contained" onClick={apply} disabled={busy || !labelingId}>
+            ラベルに反映
+          </Button>
+        </Stack>
+
+        {error && <Alert severity="error">{error}</Alert>}
+
+        <Collapse in={!!preview}>
+          {preview && (
+            <Alert severity="info">
+              {preview.candleCount} 本中: 買い {preview.counts.buy} / 売り {preview.counts.sell} /
+              利確 {preview.counts.takeProfit}
+            </Alert>
+          )}
+        </Collapse>
+      </Stack>
+    </Paper>
+  );
+};
+
+export default AutoLabelingPanel;

--- a/src/lib/labeling/index.ts
+++ b/src/lib/labeling/index.ts
@@ -1,0 +1,12 @@
+export { labelByRules } from "./strategies/ruleBased";
+export type {
+  CandleInput,
+  LabelingResult,
+  LabelKind,
+  MarkerOutput,
+  RuleBasedConfig,
+} from "./types";
+export {
+  DEFAULT_RULE_CONFIG_FX,
+  DEFAULT_RULE_CONFIG_STOCK,
+} from "./types";

--- a/src/lib/labeling/indicators/rsi.ts
+++ b/src/lib/labeling/indicators/rsi.ts
@@ -1,0 +1,30 @@
+/**
+ * RSI (Wilder's smoothing)。期間に満たない位置は null。
+ */
+export const rsi = (values: number[], period = 14): (number | null)[] => {
+  if (period <= 0) throw new Error("period must be > 0");
+  const result: (number | null)[] = new Array(values.length).fill(null);
+  if (values.length <= period) return result;
+
+  let gainSum = 0;
+  let lossSum = 0;
+  for (let i = 1; i <= period; i++) {
+    const diff = values[i] - values[i - 1];
+    if (diff >= 0) gainSum += diff;
+    else lossSum -= diff;
+  }
+
+  let avgGain = gainSum / period;
+  let avgLoss = lossSum / period;
+  result[period] = avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss);
+
+  for (let i = period + 1; i < values.length; i++) {
+    const diff = values[i] - values[i - 1];
+    const gain = diff > 0 ? diff : 0;
+    const loss = diff < 0 ? -diff : 0;
+    avgGain = (avgGain * (period - 1) + gain) / period;
+    avgLoss = (avgLoss * (period - 1) + loss) / period;
+    result[i] = avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss);
+  }
+  return result;
+};

--- a/src/lib/labeling/indicators/sma.ts
+++ b/src/lib/labeling/indicators/sma.ts
@@ -1,0 +1,18 @@
+/**
+ * Simple Moving Average. 期間に満たない位置は null。
+ */
+export const sma = (values: number[], period: number): (number | null)[] => {
+  if (period <= 0) throw new Error("period must be > 0");
+  const result: (number | null)[] = new Array(values.length).fill(null);
+  if (values.length < period) return result;
+
+  let sum = 0;
+  for (let i = 0; i < period; i++) sum += values[i];
+  result[period - 1] = sum / period;
+
+  for (let i = period; i < values.length; i++) {
+    sum += values[i] - values[i - period];
+    result[i] = sum / period;
+  }
+  return result;
+};

--- a/src/lib/labeling/runner.ts
+++ b/src/lib/labeling/runner.ts
@@ -1,0 +1,68 @@
+import prisma from "@/utils/db";
+import { labelByRules } from "./strategies/ruleBased";
+import {
+  DEFAULT_RULE_CONFIG_FX,
+  DEFAULT_RULE_CONFIG_STOCK,
+  type LabelingResult,
+  type RuleBasedConfig,
+} from "./types";
+
+export interface RunOptions {
+  symbol: string;
+  interval: string;
+  from?: Date;
+  to?: Date;
+  config?: Partial<RuleBasedConfig>;
+}
+
+export interface RunContext {
+  master: { id: number; assetType: string };
+  candleCount: number;
+  result: LabelingResult;
+  effectiveConfig: RuleBasedConfig;
+}
+
+export const runRuleBasedLabeling = async (opts: RunOptions): Promise<RunContext> => {
+  const master = await prisma.chartMaster.findUnique({
+    where: { symbol: opts.symbol },
+    select: { id: true, assetType: true },
+  });
+  if (!master) {
+    throw new Error(`ChartMaster not found for symbol ${opts.symbol}`);
+  }
+
+  const defaultConfig =
+    master.assetType === "STOCK" ? DEFAULT_RULE_CONFIG_STOCK : DEFAULT_RULE_CONFIG_FX;
+  const effectiveConfig: RuleBasedConfig = { ...defaultConfig, ...opts.config };
+
+  const where: {
+    chartMasterId: number;
+    interval: string;
+    time?: { gte?: bigint; lte?: bigint };
+  } = {
+    chartMasterId: master.id,
+    interval: opts.interval,
+  };
+  if (opts.from || opts.to) {
+    where.time = {};
+    if (opts.from) where.time.gte = BigInt(Math.floor(opts.from.getTime() / 1000));
+    if (opts.to) where.time.lte = BigInt(Math.floor(opts.to.getTime() / 1000));
+  }
+
+  const candles = await prisma.candle.findMany({
+    where,
+    orderBy: { time: "asc" },
+    select: { time: true, open: true, high: true, low: true, close: true },
+  });
+
+  const inputs = candles.map((c) => ({
+    time: Number(c.time),
+    open: c.open,
+    high: c.high,
+    low: c.low,
+    close: c.close,
+  }));
+
+  const result = labelByRules(inputs, effectiveConfig);
+  return { master, candleCount: candles.length, result, effectiveConfig };
+};

--- a/src/lib/labeling/strategies/ruleBased.ts
+++ b/src/lib/labeling/strategies/ruleBased.ts
@@ -1,0 +1,98 @@
+import { rsi } from "../indicators/rsi";
+import { sma } from "../indicators/sma";
+import type { CandleInput, LabelingResult, MarkerOutput, RuleBasedConfig } from "../types";
+
+type Position = { side: "long" | "short"; entryPrice: number; entryIndex: number } | null;
+
+const buyMarker = (time: number): MarkerOutput => ({
+  time,
+  position: "belowBar",
+  color: "#2196F3",
+  shape: "arrowUp",
+  text: `auto buy ${time}`,
+  label: 1,
+});
+
+const sellMarker = (time: number): MarkerOutput => ({
+  time,
+  position: "aboveBar",
+  color: "#e91e63",
+  shape: "arrowDown",
+  text: `auto sell ${time}`,
+  label: 2,
+});
+
+const takeProfitMarker = (time: number): MarkerOutput => ({
+  time,
+  position: "belowBar",
+  color: "#f68410",
+  shape: "circle",
+  text: `auto profit ${time}`,
+  label: 3,
+});
+
+/**
+ * SMA(short) と SMA(long) のクロス + RSI フィルタで買い/売りシグナルを生成し、
+ * `takeProfitPct` 到達 or 反対シグナルで利確マーカーを置く。
+ */
+export const labelByRules = (candles: CandleInput[], config: RuleBasedConfig): LabelingResult => {
+  const closes = candles.map((c) => c.close);
+  const shortMa = sma(closes, config.shortPeriod);
+  const longMa = sma(closes, config.longPeriod);
+  const rsiSeries = rsi(closes, config.rsiPeriod);
+
+  const markers: MarkerOutput[] = [];
+  let position: Position = null;
+
+  for (let i = 1; i < candles.length; i++) {
+    const s = shortMa[i];
+    const sPrev = shortMa[i - 1];
+    const l = longMa[i];
+    const lPrev = longMa[i - 1];
+    const r = rsiSeries[i];
+    if (s == null || sPrev == null || l == null || lPrev == null || r == null) continue;
+
+    const close = candles[i].close;
+    const time = candles[i].time;
+
+    // 利確判定（先にチェック）
+    if (position) {
+      const pct =
+        position.side === "long"
+          ? (close - position.entryPrice) / position.entryPrice
+          : (position.entryPrice - close) / position.entryPrice;
+      if (pct >= config.takeProfitPct) {
+        markers.push(takeProfitMarker(time));
+        position = null;
+        continue;
+      }
+    }
+
+    const crossUp = sPrev <= lPrev && s > l;
+    const crossDown = sPrev >= lPrev && s < l;
+
+    if (crossUp && r < config.rsiUpperBound) {
+      // 反対ポジを利確扱いで閉じる
+      if (position?.side === "short") {
+        markers.push(takeProfitMarker(time));
+      }
+      markers.push(buyMarker(time));
+      position = { side: "long", entryPrice: close, entryIndex: i };
+    } else if (crossDown && r > config.rsiLowerBound) {
+      if (position?.side === "long") {
+        markers.push(takeProfitMarker(time));
+      }
+      markers.push(sellMarker(time));
+      position = { side: "short", entryPrice: close, entryIndex: i };
+    }
+  }
+
+  const counts = {
+    buy: markers.filter((m) => m.label === 1).length,
+    sell: markers.filter((m) => m.label === 2).length,
+    takeProfit: markers.filter((m) => m.label === 3).length,
+    none: candles.length - markers.length,
+  };
+
+  return { markers, counts };
+};

--- a/src/lib/labeling/types.ts
+++ b/src/lib/labeling/types.ts
@@ -1,0 +1,55 @@
+export type LabelKind = 0 | 1 | 2 | 3; // 0:none, 1:buy, 2:sell, 3:take-profit
+
+export interface CandleInput {
+  time: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+export interface MarkerOutput {
+  time: number;
+  position: "belowBar" | "aboveBar" | "inBar";
+  color: string;
+  shape: "arrowUp" | "arrowDown" | "circle";
+  text: string;
+  label: LabelKind;
+}
+
+export interface RuleBasedConfig {
+  shortPeriod: number;
+  longPeriod: number;
+  rsiPeriod: number;
+  rsiUpperBound: number;
+  rsiLowerBound: number;
+  takeProfitPct: number; // 0.005 = 0.5%
+}
+
+export const DEFAULT_RULE_CONFIG_FX: RuleBasedConfig = {
+  shortPeriod: 5,
+  longPeriod: 20,
+  rsiPeriod: 14,
+  rsiUpperBound: 70,
+  rsiLowerBound: 30,
+  takeProfitPct: 0.005,
+};
+
+export const DEFAULT_RULE_CONFIG_STOCK: RuleBasedConfig = {
+  shortPeriod: 5,
+  longPeriod: 20,
+  rsiPeriod: 14,
+  rsiUpperBound: 70,
+  rsiLowerBound: 30,
+  takeProfitPct: 0.02,
+};
+
+export interface LabelingResult {
+  markers: MarkerOutput[];
+  counts: {
+    buy: number;
+    sell: number;
+    takeProfit: number;
+    none: number;
+  };
+}


### PR DESCRIPTION
## Summary

`docs/03-auto-labeling.md` の **Phase 1（ルールベース）** を実装。SMA クロス + RSI フィルタによる買い/売り/利確の自動ラベリングを `/chart` ページから 1 クリックで実行可能に。

これで **Phase A〜D + 仕様 02 / 04 / 03** が揃い、銘柄選択 → データ取得 → 自動ラベリング → 手動補正 → エクスポート、という E2E フローが UI 上で完結します。

## 主な変更

### ライブラリ構成

```
src/lib/labeling/
├── index.ts                    # 公開エントリ
├── types.ts                    # RuleBasedConfig, デフォルト値
├── runner.ts                   # Prisma → 戦略実行のオーケストレーション
├── strategies/
│   └── ruleBased.ts            # Phase 1 戦略
└── indicators/
    ├── sma.ts                  # Simple MA
    └── rsi.ts                  # RSI (Wilder)
```

### ルール（Phase 1）

| シグナル | 条件 |
|---------|------|
| **買い** | SMA(short) が SMA(long) を上抜け **かつ** RSI < `rsiUpperBound` |
| **売り** | SMA(short) が SMA(long) を下抜け **かつ** RSI > `rsiLowerBound` |
| **利確** | 保有中 `takeProfitPct` 到達 / 反対シグナル発生時に保有を利確クローズ |

デフォルト：FX `0.5%`、株 `2.0%`。`shortPeriod=5 / longPeriod=20 / rsiPeriod=14 / rsiUpperBound=70 / rsiLowerBound=30`

### API エンドポイント

| ルート | 用途 |
|------|------|
| `POST /api/labeling/auto/preview` | DB に保存せず結果のみ返却（UI プレビュー） |
| `POST /api/labeling/auto` | `Labeling.markers` に反映 + `AutoLabelRun` 履歴記録 |

`auto` の `overwrite=false`（デフォルト）時は既存マーカーとマージ、同時刻は後勝ちで上書き。

### UI

**`AutoLabelingPanel.tsx`** を新規追加し `/chart` 右カラムに統合：
- 時間足セレクタ（`assetType` に応じた候補）
- 短期/長期 SMA、RSI 期間、利確 % のテキスト入力
- 上書きチェックボックス
- **プレビュー** ボタン → 候補件数を Alert 表示（DB 影響なし）
- **ラベルに反映** ボタン → 適用後ページリロード

## 検証結果

- `npm run build`：**`✓ Compiled successfully`**、Static **18/18**（新ルート 2 本含む）
- `npm run lint`：エラー 0、警告 19（既存品質）

## 既知の制約・残件

- Phase 2（LLM 補助）と Phase 3（ML モデル）は別タスクで段階的に実装
- 自動ラベリングのバックテスト指標（勝率・PF）算出 UI は未実装
- 大量データの bulk 最適化（`createMany` / raw query）は必要に応じて追加

## Test plan（実環境）

- [ ] Postgres 起動 → `npm run db:migrate` → `npm run db:seed`
- [ ] `/admin/data` で `7203.T` の `1d` を取得（数年分）
- [ ] `/chart` で株タブ → `7203.T` 選択
- [ ] `CreateLabeling` で新規ラベリング作成
- [ ] `AutoLabelingPanel` で「プレビュー」→ 件数表示を確認
- [ ] 「ラベルに反映」→ チャートにマーカーが表示されることを確認
- [ ] `psql` で `auto_label_runs` テーブルに履歴が残っていることを確認
- [ ] FX タブで同様の操作 → デフォルト利確が `0.5%` になっていること

## ロードマップ

これで仕様書 00〜06 の主要実装はすべて main に揃います。次の候補は：

1. Phase E（残メジャーアップ：MUI 6, lightweight-charts 5, etc.）
2. Phase 2（LLM 補助による自動ラベリング検証）
3. バックテスト・性能評価 UI
4. スケジュール自動データ取得（Vercel Cron / GitHub Actions）

https://claude.ai/code/session_01AGh3ja6X8ZsgX3U6MyBgGZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGh3ja6X8ZsgX3U6MyBgGZ)_